### PR TITLE
added ?refresh=true to url

### DIFF
--- a/custom_components/hd_powerview/cover.py
+++ b/custom_components/hd_powerview/cover.py
@@ -149,7 +149,7 @@ class PowerView:
 
     def get_shade(self, shade):
         """List all shades."""
-        request = self.make_request("get","/api/shades/" + str(shade))
+        request = self.make_request("get","/api/shades/" + str(shade) + "?refresh=true")
 
         if request != False:
             shade = Shade(request['shade']['id'], b64decode(request['shade']['name']).decode('UTF-8'), round((request['shade']['positions']['position1'] / 65535) * 100), round(request['shade']['batteryStrength'] / 2))
@@ -159,7 +159,7 @@ class PowerView:
 
     def get_status(self, shade):
         """Update status of shade."""
-        request = round((self.make_request("get","/api/shades/" + str(shade))['shade']['positions']['position1'] / 65535) * 100)
+        request = round((self.make_request("get","/api/shades/" + str(shade) + "?refresh=true")['shade']['positions']['position1'] / 65535) * 100)
         return request
 
     def close_shade(self, shade):


### PR DESCRIPTION
The Powerview hub caches battery_level and position values. Therefore a call to /api/shades instantly returns cached values. 
?refresh=true must be appended to the url, otherwise position value never gets updated.

This change makes the integration to slow down considerably. Maybe even HA itself. Every entity requires 3 to 5 seconds to update. 15 seconds polling interval to all entities doesn't make the system any faster.

This change also makes stop button almost unusable. And still - it's a change that have to be made.